### PR TITLE
Fix#57: Add new design in education section.

### DIFF
--- a/frontend/src/components/options/education/option4.js
+++ b/frontend/src/components/options/education/option4.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+const Option4 = ({ educationTitle, education }) => {
+  return (
+    <section className="w-full h-auto flex justify-center items-center mt-16" id="education" style={{ fontFamily: 'monospace' }}>
+      {/* Container for all education content */}
+      <div className="relative w-[90%] md:w-[70%] border border-gray-800/[50] rounded-[18px] p-6 bg-black/20">
+        
+        {/* Education Title sitting on the border with invisible border behind */}
+        <div
+          className="absolute -top-5 left-1/4 transform -translate-x-1/2 bg-black px-4 text-blue-300 text-2xl"
+          style={{ fontFamily: 'monospace', borderTop: 'none' }} // Positioning it on the border
+        >
+          {educationTitle}
+        </div>
+
+        {/* Border styling adjustment (for hiding behind the heading) */}
+        <div className="border-t-0 pt-6"></div>
+
+        {/* Education List */}
+        <div className="mt-1 flex flex-col">
+          {education && education.map((item, index) => (
+            <div
+              key={index}
+              className="relative w-full p-4"
+              style={{ backgroundColor: 'transparent', color: '#e5e5e5' }}
+            >
+              {/* University Name and Degree */}
+              <div className="flex justify-between items-center">
+                <div className="text-sm font-normal">
+                  • {item.education.university}
+                </div>
+
+                {/* CGPA */}
+                <div className="text-sm" style={{ color: '#8ab4f8' }}>
+                  CGPA: {item.education.gpa}
+                </div>
+              </div>
+
+              {/* Degree and Branch */}
+              <div className="text-sm mt-2 pl-5">
+                - {item.education.degree}, {item.education.branch}
+              </div>
+
+              {/* Date */}
+              <div className="text-xs mt-1 pl-5">
+                {`${item.education.start} - ${item.education.end ? item.education.end : item.education.presentJob ? 'Present' : ''}`}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Option4;

--- a/frontend/src/components/options/education/option4.js
+++ b/frontend/src/components/options/education/option4.js
@@ -14,7 +14,7 @@ const Option4 = ({ educationTitle, education }) => {
           {educationTitle}
         </div>
 
-        {/* Border styling adjustment (for hiding behind the heading) */}
+        {/* Border styling adjustment*/}
         <div className="border-t-0 pt-6"></div>
 
         {/* Education List */}

--- a/frontend/src/components/portfolioCard.jsx
+++ b/frontend/src/components/portfolioCard.jsx
@@ -21,6 +21,7 @@ import Experience2 from "./options/experience/option2";
 import EducationDesign1 from './options/education/option1'
 import EducationDesign2 from './options/education/option2'
 import EducationDesign3 from './options/education/option3'
+import EducationDesign4 from './options/education/option4'
 import GetInTouch from './options/getInTouch/option1'
 import Code from "./Code";
 
@@ -249,6 +250,14 @@ const PortfolioCard = (state, {
     case "Option3":
       selectedEducationDesign = ReactDOMServer.renderToString(
         <EducationDesign3 
+        educationTitle = {state.educationTitle}
+        education = {state.educations}
+        />
+      );
+      break;
+      case "Option4":
+      selectedEducationDesign = ReactDOMServer.renderToString(
+        <EducationDesign4 
         educationTitle = {state.educationTitle}
         education = {state.educations}
         />
@@ -505,7 +514,17 @@ const PortfolioCard = (state, {
                   color: educationSection === "Option3" ? "white" : "black",
               }} 
             >Education Design 3</div>
+            <div 
+              className="p-2 rounded-md bg-blue-400 cursor-pointer hover:scale-[1.02] border" 
+              onClick={() => handleEducationChange("Option4")}
+              style={{
+                background:
+                  educationSection === "Option4" ? "lightblue" : "white",
+                  color: educationSection === "Option4" ? "white" : "black",
+              }} 
+            >Education Design 4</div>
           </div>
+          
 
             <Form
               FormData={{
@@ -664,3 +683,4 @@ const mapStateToProps = (state) => ({
 });
 
 export default connect(mapStateToProps)(PortfolioCard);
+


### PR DESCRIPTION
## Visual Reference 
The attached image visually represents the intended design for the Education section, showcasing the layout and styling.

<img width="1470" alt="Screenshot 2024-10-14 at 1 46 39 AM" src="https://github.com/user-attachments/assets/49c03430-99aa-4d60-8b11-3431f6acccbb">

Please review the changes and provide feedback or merge. Thank you!
closes #57
